### PR TITLE
Php version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.4"
+        "php": ">=7.3"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3"


### PR DESCRIPTION
Not installing with php 7.3:
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - amiriun/sms dev-master requires php ^7.4 -> your PHP version (7.3.8) does not satisfy that requirement.